### PR TITLE
Add davy.ai to blocklist

### DIFF
--- a/list.txt
+++ b/list.txt
@@ -23,6 +23,7 @@
 ! Sites that have .ai domain extension
 google.com,duckduckgo.com,bing.com##a[href*="animegenius.ai"]:upward(div):style(opacity:0.00!important;)
 google.com,duckduckgo.com,bing.com##a[href*="artvy.ai"]:upward(div):style(opacity:0.00!important;)
+google.com,duckduckgo.com,bing.com##a[href*="davy.ai"]:upward(div):style(opacity:0.00!important;)
 google.com,duckduckgo.com,bing.com##a[href*="plugger.ai"]:upward(div):style(opacity:0.00!important;)
 google.com,duckduckgo.com,bing.com##a[href*="zavant.ai"]:upward(div):style(opacity:0.00!important;)
 google.com,duckduckgo.com,bing.com##a[href*="openart.ai"]:upward(div):style(opacity:0.00!important;)

--- a/list_uBlacklist.txt
+++ b/list_uBlacklist.txt
@@ -19,6 +19,7 @@
 # Sites that have .ai domain extension
 *://*.animegenius.ai/*
 *://*.artvy.ai/*
+*://*.davy.ai/*
 *://*.plugger.ai/*
 *://*.zavant.ai/*
 *://*.openart.ai/*


### PR DESCRIPTION
This website seems to be pure content farm, copying stack overflow question and replace all answers with ai generated hallucinations.