### PR TITLE
Getting rid of google ai overview

### DIFF
--- a/list.txt
+++ b/list.txt
@@ -1559,6 +1559,8 @@ google.com,duckduckgo.com,bing.com##a[href*="tiktok.com/@ku_13js"]:upward(div):s
 
 ! // [Placeholder] Operation: Baby Peacock (Removing AI-generated Animal Misinformation/Images; Non-categorized)
 
+! // Google AI Overview
+google.com##.YzCcne
 
 ! // Just in case exceptions
 mail.google.com#@#a[href*="/play.ht"]:upward(div):style(opacity:0.00!important;)


### PR DESCRIPTION
closes #66 

I don't know how effective this method will be in blocking it long term, hardly an easy way. Tested on latest Brave browser version, unsure if this works everywhere, so would like someone to test. 