### PR TITLE
Added a few websites from a deprecated Blocklist

### DIFF
--- a/additional_list_nuclear.txt
+++ b/additional_list_nuclear.txt
@@ -59,6 +59,7 @@ google.com,duckduckgo.com,bing.com##a[href*="kemono.party"]:upward(div):style(op
 google.com,duckduckgo.com,bing.com##a[href*="alphacoders.com"]:upward(div):style(opacity:0.00!important;)
 google.com,duckduckgo.com,bing.com##a[href*="rollingpress.co.ke"]:upward(div):style(opacity:0.00!important;)
 google.com,duckduckgo.com,bing.com##a[href*="ukposters.co.uk"]:upward(div):style(opacity:0.00!important;)
+google.com,duckduckgo.com,bing.com##a[href*="redbrokoly.com"]:upward(div):style(opacity:0.00!important;)
 
 ! // Content Aggregators/SEO spam
 google.com,duckduckgo.com,bing.com##a[href*="tnhelearning.edu.vn"]:upward(div):style(opacity:0.00!important;)

--- a/list.txt
+++ b/list.txt
@@ -346,6 +346,8 @@ google.com,duckduckgo.com,bing.com##a[href*="neoprompt.ai"]:upward(div):style(op
 google.com,duckduckgo.com,bing.com##a[href*="thedream.ai"]:upward(div):style(opacity:0.00!important;)
 google.com,duckduckgo.com,bing.com##a[href*="viggle.ai"]:upward(div):style(opacity:0.00!important;)
 google.com,duckduckgo.com,bing.com##a[href*="llamagen.ai"]:upward(div):style(opacity:0.00!important;)
+google.com,duckduckgo.com,bing.com##a[href*="gab.ai"]:upward(div):style(opacity:0.00!important;)
+google.com,duckduckgo.com,bing.com##a[href*="mascots.ai"]:upward(div):style(opacity:0.00!important;)
 
 
 ! Sites that have .com domain extension
@@ -643,6 +645,12 @@ google.com,duckduckgo.com,bing.com##a[href*="drawever.com"]:upward(div):style(op
 google.com,duckduckgo.com,bing.com##a[href*="smiletemplates.com/search/images"]:upward(div):style(opacity:0.00!important;)
 google.com,duckduckgo.com,bing.com##a[href*="beatcoynz-artwork.com"]:upward(div):style(opacity:0.00!important;)
 google.com,duckduckgo.com,bing.com##a[href*="stlmax.com"]:upward(div):style(opacity:0.00!important;)
+google.com,duckduckgo.com,bing.com##a[href*="ebsynth.com"]:upward(div):style(opacity:0.00!important;)
+google.com,duckduckgo.com,bing.com##a[href*="ishencai.com"]:upward(div):style(opacity:0.00!important;)
+google.com,duckduckgo.com,bing.com##a[href*="metademolab.com"]:upward(div):style(opacity:0.00!important;)
+google.com,duckduckgo.com,bing.com##a[href*="softgist.com"]:upward(div):style(opacity:0.00!important;)
+google.com,duckduckgo.com,bing.com##a[href*="vondy.com"]:upward(div):style(opacity:0.00!important;)
+google.com,duckduckgo.com,bing.com##a[href*="aitoolhunt.com"]:upward(div):style(opacity:0.00!important;)
 
 ! Sites that have .art domain extension
 google.com,duckduckgo.com,bing.com##a[href*="imagine.art"]:upward(div):style(opacity:0.00!important;)
@@ -934,6 +942,8 @@ google.com,duckduckgo.com,bing.com##a[href*="stablediffusion.blog"]:upward(div):
 google.com,duckduckgo.com,bing.com##a[href*="distinctplugins.io"]:upward(div):style(opacity:0.00!important;)
 google.com,duckduckgo.com,bing.com##a[href*="nohat.cc"]:upward(div):style(opacity:0.00!important;)
 google.com,duckduckgo.com,bing.com##a[href*="stl.team"]:upward(div):style(opacity:0.00!important;)
+google.com,duckduckgo.com,bing.com##a[href*="idesigns.shop"]:upward(div):style(opacity:0.00!important;)
+google.com,duckduckgo.com,bing.com##a[href*="bottr.me"]:upward(div):style(opacity:0.00!important;)
 
 
 ! Google Play AI applications
@@ -1240,6 +1250,7 @@ google.com,duckduckgo.com,bing.com##a[href*="youtube.com/@enigmatic_e"]:upward(d
 google.com,duckduckgo.com,bing.com##a[href*="youtube.com/channel/UClSBolYONOzQjOzE4cMHfpw"]:upward(div):style(opacity:0.00!important;)
 google.com,duckduckgo.com,bing.com##a[href*="youtube.com/@LaCarnevali"]:upward(div):style(opacity:0.00!important;)
 google.com,duckduckgo.com,bing.com##a[href*="youtube.com/@OlivioSarikas"]:upward(div):style(opacity:0.00!important;)
+google.com,duckduckgo.com,bing.com##a[href*="youtube.com/@alkaid-art"]:upward(div):style(opacity:0.00!important;)
 
 
 ! Block list of AI "artists"/orgs (instagram)

--- a/list_uBlacklist.txt
+++ b/list_uBlacklist.txt
@@ -342,6 +342,8 @@
 *://*.thedream.ai/*
 *://*.viggle.ai/*
 *://*.llamagen.ai/*
+*://*.gab.ai/*
+*://*.mascots.ai/*
 
 
 # Sites that have .com domain extension
@@ -639,6 +641,12 @@
 *://*.smiletemplates.com/search/images/*
 *://*.beatcoynz-artwork.com/*
 *://*.stlmax.com/*
+*://*.ebsynth.com/*
+*://*.ishencai.com/*
+*://*.metademolab.com/*
+*://*.softgist.com/*
+*://*.vondy.com/*
+*://*.aitoolhunt.com/*
 
 
 # Sites that have .art domain extension
@@ -931,6 +939,8 @@
 *://*.distinctplugins.io/*
 *://*.nohat.cc/*
 *://*.stl.team/*
+*://*.idesigns.shop/*
+*://*.bottr.me/*
 
 
 # AI projects hosted on other sites
@@ -1246,6 +1256,7 @@
 *://*.youtube.com/channel/UClSBolYONOzQjOzE4cMHfpw/*
 *://*.youtube.com/@LaCarnevali/*
 *://*.youtube.com/@OlivioSarikas/*
+*://*.youtube.com/@alkaid-art/*
 
 
 # Block list of AI "artists"/orgs (instagram)

--- a/list_uBlacklist_nuclear.txt
+++ b/list_uBlacklist_nuclear.txt
@@ -45,6 +45,7 @@
 *://*.alphacoders.com/*
 *://*.rollingpress.co.ke/*
 *://*.ukposters.co.uk/*
+*://*.redbrokoly.com/*
 
 # // Content Aggregators/SEO spam
 *://*.tnhelearning.edu.vn/*


### PR DESCRIPTION
"There was an AI Blocklist on Codeberg that seems to have disappeared. I had an archive of it, so I added the sites that were on it that weren't here to the list. I also attempted to amp up security for known sites like alkaidvision and kakaobrain on the UBlacklist lists.
Sites added: ebsynth.com, ishencai.com, metademolab.com, softgist.com, vondy.com, aitoolhunt.com, mascots.ai, gab.ai, idesigns.shop, bottr.me, youtube.com/@alkaid-art"
Reposted due to merge conflicts.