### PR TITLE
adding cybersecguide.com,krisp.ai,fireflies.ai,otter.ai

### DIFF
--- a/list.txt
+++ b/list.txt
@@ -355,6 +355,7 @@ google.com,duckduckgo.com,bing.com##a[href*="moescape.ai"]:upward(div):style(opa
 
 
 ! Sites that have .com domain extension
+google.com,duckduckgo.com,bing.com##a[href*="steelefortress.com"]:upward(div):style(opacity:0.00!important;)
 google.com,duckduckgo.com,bing.com##a[href*="cybersecguide.com"]:upward(div):style(opacity:0.00!important;)
 google.com,duckduckgo.com,bing.com##a[href*="chatbot.com"]:upward(div):style(opacity:0.00!important;)
 google.com,duckduckgo.com,bing.com##a[href*="aicreate.com"]:upward(div):style(opacity:0.00!important;)
@@ -800,6 +801,7 @@ google.com,duckduckgo.com,bing.com##a[href*="vitalentum.net"]:upward(div):style(
 
 
 ! Sites that have miscellaneous domain extensions (.pub, .io, .cc, et cetera)
+google.com,duckduckgo.com,bing.com##a[href*="nbcsport.co.uk"]:upward(div):style(opacity:0.00!important;)
 google.com,duckduckgo.com,bing.com##a[href*="getmerlin.in"]:upward(div):style(opacity:0.00!important;)
 google.com,duckduckgo.com,bing.com##a[href*="aitree.io"]:upward(div):style(opacity:0.00!important;)
 google.com,duckduckgo.com,bing.com##a[href*="transpic.cn"]:upward(div):style(opacity:0.00!important;)

--- a/list.txt
+++ b/list.txt
@@ -21,6 +21,9 @@
 !//// Sites hosting nothing but AI generated content/solely focused on AI/has an abundance of AI generated imagery... 100% confirmed
 
 ! Sites that have .ai domain extension
+google.com,duckduckgo.com,bing.com##a[href*="otter.ai"]:upward(div):style(opacity:0.00!important;)
+google.com,duckduckgo.com,bing.com##a[href*="fireflies.ai"]:upward(div):style(opacity:0.00!important;)
+google.com,duckduckgo.com,bing.com##a[href*="krisp.ai"]:upward(div):style(opacity:0.00!important;)
 google.com,duckduckgo.com,bing.com##a[href*="julius.ai"]:upward(div):style(opacity:0.00!important;)
 google.com,duckduckgo.com,bing.com##a[href*="cgdream.ai"]:upward(div):style(opacity:0.00!important;)
 google.com,duckduckgo.com,bing.com##a[href*="tryleap.ai"]:upward(div):style(opacity:0.00!important;)
@@ -351,6 +354,7 @@ google.com,duckduckgo.com,bing.com##a[href*="mascots.ai"]:upward(div):style(opac
 
 
 ! Sites that have .com domain extension
+google.com,duckduckgo.com,bing.com##a[href*="cybersecguide.com"]:upward(div):style(opacity:0.00!important;)
 google.com,duckduckgo.com,bing.com##a[href*="chatbot.com"]:upward(div):style(opacity:0.00!important;)
 google.com,duckduckgo.com,bing.com##a[href*="aicreate.com"]:upward(div):style(opacity:0.00!important;)
 google.com,duckduckgo.com,bing.com##a[href*="appypie.com"]:upward(div):style(opacity:0.00!important;)

--- a/list_uBlacklist.txt
+++ b/list_uBlacklist.txt
@@ -351,6 +351,7 @@
 
 
 # Sites that have .com domain extension
+*://*.steelefortress.com/*
 *://*.cybersecguide.com/*
 *://*.appypie.com/*
 *://*.aicreate.com/*
@@ -797,6 +798,7 @@
 
 
 # Sites that have miscellaneous domain extensions (.pub, .io, .cc, et cetera)
+*://*.domain/*
 *://*.getmerlin.in/*
 *://*.transpic.cn/*
 *://*.aitree.io/*

--- a/list_uBlacklist.txt
+++ b/list_uBlacklist.txt
@@ -17,6 +17,9 @@
 #//// Sites hosting nothing but AI generated content/solely focused on AI/has an abundance of AI generated imagery... 100% confirmed
 
 # Sites that have .ai domain extension
+*://*.otter.ai/*
+*://*.fireflies.ai/*
+*://*.krisp.ai/*
 *://*.cgdream.ai/*
 *://*.tryleap.ai/*
 *://*.magichour.ai/*
@@ -347,6 +350,7 @@
 
 
 # Sites that have .com domain extension
+*://*.cybersecguide.com/*
 *://*.appypie.com/*
 *://*.aicreate.com/*
 *://*.toolbaz.com/*


### PR DESCRIPTION
Adding some new sites to the regular lists

- Three sites that perform AI-based meeting eavesdropping krisp.ai,fireflies.ai,otter.ai
- One site that appears to be fully popoulated with non-useful AI content cybersecguide.com