### PR TITLE
4 new websites added

### DIFF
--- a/list_uBlacklist.txt
+++ b/list_uBlacklist.txt
@@ -672,6 +672,7 @@
 *://*.aipromptsdirectory.com/*
 *://*.songtell.com/*
 *://*.prompt-com.com/*
+*://*.peopleai.com/*
 
 
 # Sites that have .art domain extension

--- a/list_uBlacklist.txt
+++ b/list_uBlacklist.txt
@@ -673,6 +673,7 @@
 *://*.songtell.com/*
 *://*.prompt-com.com/*
 *://*.peopleai.com/*
+*://*.airportcalgary.com/*
 
 
 # Sites that have .art domain extension
@@ -818,6 +819,7 @@
 *://*.heatware.net/*
 *://*.bigshadows.net/*
 *://*.eyecandy.net/*
+*://*.jeddahairport.net/*
 
 
 # Sites that have miscellaneous domain extensions (.pub, .io, .cc, et cetera)

--- a/list_uBlacklist.txt
+++ b/list_uBlacklist.txt
@@ -674,6 +674,7 @@
 *://*.prompt-com.com/*
 *://*.peopleai.com/*
 *://*.airportcalgary.com/*
+*://*.dogbreedadvice.com/*
 
 
 # Sites that have .art domain extension


### PR DESCRIPTION
Added 4 SEO leeches to the list.

AI generated imagery present in `airportcalgary.com`, `jeddahairport.net` and `dogbreedadvice.com`

`peopleai.com` is sloppy summaries and broken graphs.

Resolves #139 #130 