### PR TITLE
Remove Gmail's, Google Drive's, Google Doc's "Try Gemini" button

### DIFF
--- a/list.txt
+++ b/list.txt
@@ -3625,4 +3625,4 @@ mail.google.com#@#a[href*="/play.ht"]:upward(2):remove()
 mail.google.com#@#a[href*=".play.ht"]:upward(2):remove()
 
 ! // Gmail: Try Gemini button
-mail.google.com##div[role="tooltip"]:has-text(Try Gemini):upward(3)
+mail.google.com##div[role="tooltip"]:has-text(Try Gemini):upward(3):remove()

--- a/list.txt
+++ b/list.txt
@@ -3624,5 +3624,5 @@ github.com##li > a[href$="/copilot"]:upward(li)
 mail.google.com#@#a[href*="/play.ht"]:upward(2):remove()
 mail.google.com#@#a[href*=".play.ht"]:upward(2):remove()
 
-! // Gmail: Try Gemini button
-mail.google.com##div[role="tooltip"]:has-text(Try Gemini):upward(3):remove()
+! // Gmail, Google Drive, Google Docs: Try Gemini button
+mail.google.com,drive.google.com,docs.google.com##div[role="tooltip"]:has-text(Try Gemini):upward(3):remove()

--- a/list.txt
+++ b/list.txt
@@ -3623,3 +3623,6 @@ github.com##li > a[href$="/copilot"]:upward(li)
 ! // Just in case exceptions
 mail.google.com#@#a[href*="/play.ht"]:upward(2):remove()
 mail.google.com#@#a[href*=".play.ht"]:upward(2):remove()
+
+! // Gmail: Try Gemini button
+mail.google.com##div[role="tooltip"]:has-text(Try Gemini):upward(3)


### PR DESCRIPTION
Gmail, Google Drive, etc has a Try Gemini button in the menu bar next to settings. This rule will remove it.

Before:
![image](https://github.com/user-attachments/assets/c9bc8d5e-8481-46b0-a490-dabe5e20b431)

After:
![image](https://github.com/user-attachments/assets/883484b8-5a1c-4641-989a-666f1dc1c9b3)
