### PR TITLE
Remove the AI Mode tab in google search results

### DIFF
--- a/list.txt
+++ b/list.txt
@@ -3612,6 +3612,8 @@ google.com##a[href*="redbubble.com/people/digitalemporio/shop"]:upward(2):remove
 ! // Google AI Overview
 google.com##.YzCcne:remove()
 
+! // Google AI Mode search tab
+google.com##div[role="navigation"] span:has-text(AI Mode):upward(5):remove()
 
 ! // GitHub Copilot
 github.com##div > button > span > span > svg.octicon-copilot:upward(div)


### PR DESCRIPTION
Removes the "AI Mode" tab that appears in the search results.

<img width="590" height="123" alt="A google search, with the AI Mode tab to the left of the All results tab, directly underneath the google logo and the search bar" src="https://github.com/user-attachments/assets/0a931696-e896-40fc-b604-9563d202e156" />