### PR TITLE
Add bardai.ai

### DIFF
--- a/list.txt
+++ b/list.txt
@@ -361,6 +361,7 @@ duckduckgo.com,bing.com##a[href*="boodlebox.ai"]:upward(li):remove()
 duckduckgo.com,bing.com##a[href*="sunoai.ai"]:upward(li):remove()
 duckduckgo.com,bing.com##a[href*="thetawise.ai"]:upward(li):remove()
 duckduckgo.com,bing.com##a[href*="imagineanything.ai"]:upward(li):remove()
+duckduckgo.com,bing.com##a[href*="bardai.ai"]:upward(li):remove()
 
 
 ! Sites that have .com domain extension

--- a/list_uBlacklist.txt
+++ b/list_uBlacklist.txt
@@ -357,6 +357,7 @@
 *://*.Sunoai.ai/*
 *://*.thetawise.ai/*
 *://*.imagineanything.ai/*
+*://*.bardai.ai/*
 
 
 # Sites that have .com domain extension

--- a/noai_hosts.txt
+++ b/noai_hosts.txt
@@ -354,6 +354,7 @@
 0.0.0.0 sunoai.ai
 0.0.0.0 thetawise.ai
 0.0.0.0 imagineanything.ai
+0.0.0.0 bardai.ai
 
 
 # [.com sites]
@@ -2298,4 +2299,5 @@
 0.0.0.0 www.homediningkitchen.com
 0.0.0.0 www.psichologyanswers.com
 0.0.0.0 www.umatechnology.org
+
 


### PR DESCRIPTION
Full of AI slop, likely uses a name similar to "Bard" (presently known as "Gemini") paired with "AI" in order to farm misled users looking for "Bard" unaware of the previous name change.