### PR TITLE
AI-generated answer site that gets indexed by search engines (glarity.app, askai.glarity.app)

### DIFF
--- a/list_uBlacklist.txt
+++ b/list_uBlacklist.txt
@@ -998,6 +998,7 @@
 *://*.sunoai.asia/*
 *://*.diffus.me/*
 *://*.deepwiki.org/*
+*://*.glarity.app/*
 
 # AI projects hosted on other sites
 *://*.canva.com/ai-art-generator/*

--- a/noai_hosts.txt
+++ b/noai_hosts.txt
@@ -964,6 +964,8 @@
 0.0.0.0 scpa.education
 0.0.0.0 sunoai.asia
 0.0.0.0 diffus.me
+0.0.0.0 glarity.app
+0.0.0.0 askai.glarity.app
 
 
 # [AI Projects Hosted on Other Sites]


### PR DESCRIPTION
wish they would put some kind of robots.txt restriction so all their answer pages didnt keep showing up when i try and look stuff up (like im fine with your landing pages getting indexed, but please dont blatantly flood my search results with ai-generated crap i never asked for)

personally im currently controlling this by asking my search engine to exclude the site from my search results (thank you so much duckduckgo, legendary feature) but i have had to see it enough times to get annoyed enough to want it very gone.  im suspecting that anyone using this blocklist probably also wouldnt mind having the site on it.