### PR TITLE
.gitattributes: Specify AdBlock type for list.txt

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+list.txt linguist-language=AdBlock linguist-detectable


### PR DESCRIPTION
Create .gitattributes file to specify list.txt as an AdBlock Filter List. Adds syntax highlighting when viewing filter file and lists AdBlock Filter List under languages in GitHub.

See https://github.com/github-linguist/linguist/blob/main/docs/overrides.md

Also done in EasyList: https://github.com/easylist/easylist/blob/master/.gitattributes